### PR TITLE
exposing parameter_group_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_elasticache_cluster" "redis" {
   maintenance_window = "${var.maintenance_window}"
   node_type = "${var.instance_type}"
   num_cache_nodes = "1"
-  parameter_group_name = "default.redis2.8"
+  parameter_group_name = "${var.parameter_group_name}"
   port = "6379"
   subnet_group_name = "${aws_elasticache_subnet_group.default.name}"
   security_group_ids = ["${aws_security_group.redis.id}"]

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ module "elasticache_redis" {
 - `instance_type` - Instance type for cache instance (default: `cache.m3.medium`)
 - `maintenance_window` - 60 minute time window to reserve for maintenance
   (default: `sun:05:00-sun:06:00`)
+- `parameter_group_name` - Name of the parameter group to associate with this cache cluster (default: `default.redis2.8`)
 - `tag_name`
 - `tag_environment`
 - `tag_team`

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,10 @@ variable "engine_version" {
   default = "2.8.24"
 }
 
+variable "parameter_group_name" {
+  default = "default.redis2.8"
+}
+
 variable "instance_type" {
   default = "cache.m3.medium"
 }


### PR DESCRIPTION
In order to override the default parameter group name, the parameter_group_name variable must be exposed. This allows the setting of redis specific parameters.