### PR TITLE
Updates for newer Terraform versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,40 +1,40 @@
 resource "aws_security_group" "redis" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = var.vpc_id
 
   tags {
-    Name          = "${var.tag_name}"
-    environment   = "${var.tag_environment}"
-    team          = "${var.tag_team}"
-    application   = "${var.tag_application}"
-    contact-email = "${var.tag_contact-email}"
-    tag_customer  = "${var.tag_customer}"
+    Name          = var.tag_name
+    environment   = var.tag_environment
+    team          = var.tag_team
+    application   = var.tag_application
+    contact-email = var.tag_contact-email
+    tag_customer  = var.tag_customer
   }
 }
 
 resource "aws_elasticache_subnet_group" "default" {
   name        = "subnet-group-${var.tag_team}-${var.tag_application}-${var.tag_environment}"
   description = "Private subnets for the ElastiCache instances: ${var.tag_team} ${var.tag_application} ${var.tag_environment}"
-  subnet_ids  = ["${split(",", var.private_subnet_ids)}"]
+  subnet_ids  = "${split(",", var.private_subnet_ids)}"
 }
 
 resource "aws_elasticache_cluster" "redis" {
-  cluster_id           = "${var.cluster_id}"
+  cluster_id           = var.cluster_id
   engine               = "redis"
-  engine_version       = "${var.engine_version}"
-  maintenance_window   = "${var.maintenance_window}"
-  node_type            = "${var.instance_type}"
+  engine_version       = var.engine_version
+  maintenance_window   = var.maintenance_window
+  node_type            = var.instance_type
   num_cache_nodes      = "1"
-  parameter_group_name = "${var.parameter_group_name}"
+  parameter_group_name = var.parameter_group_name
   port                 = "6379"
-  subnet_group_name    = "${aws_elasticache_subnet_group.default.name}"
-  security_group_ids   = ["${aws_security_group.redis.id}"]
+  subnet_group_name    = aws_elasticache_subnet_group.default.name
+  security_group_ids   = [aws_security_group.redis.id]
 
   tags {
-    Name          = "${var.tag_name}"
-    environment   = "${var.tag_environment}"
-    team          = "${var.tag_team}"
-    application   = "${var.tag_application}"
-    contact-email = "${var.tag_contact-email}"
-    tag_customer  = "${var.tag_customer}"
+    Name          = var.tag_name
+    environment   = var.tag_environment
+    team          = var.tag_team
+    application   = var.tag_application
+    contact-email = var.tag_contact-email
+    tag_customer  = var.tag_customer
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,13 @@
 output "cache_security_group_id" {
-  value = "${aws_security_group.redis.id}"
+  value = aws_security_group.redis.id
 }
 
 output "hostname" {
-  value = "${aws_elasticache_cluster.redis.cache_nodes.0.address}"
+  value = aws_elasticache_cluster.redis.cache_nodes.0.address
 }
 
 output "port" {
-  value = "${aws_elasticache_cluster.redis.cache_nodes.0.port}"
+  value = aws_elasticache_cluster.redis.cache_nodes.0.port
 }
 
 output "endpoint" {


### PR DESCRIPTION
This PR removes the string interpolation that was required with earlier versions off Terraform and fixes Subnets to be a string instead of an array.